### PR TITLE
Make webcam resource work across multiple platforms

### DIFF
--- a/examples/webcam/grim.toml
+++ b/examples/webcam/grim.toml
@@ -1,8 +1,5 @@
 [webcam]
-#windows
-pipeline = "ksvideosrc ! videoconvert ! video/x-raw,format=BGRA ! appsink name=appsink async=false sync=false"
-#macos
-#pipeline = "autovideosrc ! video/x-raw,format=BGRA ! appsink name=appsink async=false sync=false"
+webcam = true
 
 
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -55,7 +55,12 @@ impl Video {
     }
 
     pub fn new_webcam() -> Result<Self> {
+        #[cfg(target_os = "macos")]
         let pipeline = "autovideosrc ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
+        #[cfg(target_os = "linux")]
+        let pipeline = "autovideosrc ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
+        #[cfg(target_os = "windows")]
+        let pipeline = "ksvideosrc ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
         let pipeline = gst::parse_launch(&pipeline).map_err(|e| Error::gstreamer(e.to_string()))?;
         let sink = pipeline
             .clone()

--- a/src/video.rs
+++ b/src/video.rs
@@ -60,7 +60,7 @@ impl Video {
         #[cfg(target_os = "linux")]
         let pipeline = "autovideosrc ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
         #[cfg(target_os = "windows")]
-        let pipeline = "ksvideosrc ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
+        let pipeline = "ksvideosrc ! videoconvert ! video/x-raw,format=RGB,format=RGBA,format=BGR,format=BGRA ! appsink name=appsink async=false sync=false";
         let pipeline = gst::parse_launch(&pipeline).map_err(|e| Error::gstreamer(e.to_string()))?;
         let sink = pipeline
             .clone()


### PR DESCRIPTION
Use conditional compilation to hardcode different webcam gstreamer pipelines
for each platform. I'm not certain if the linux pipeline works, but it's
a fine placeholder for now.

Closes #32