### PR TITLE
Squashed goodies from issue-34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,20 +276,20 @@ dependencies = [
 
 [[package]]
 name = "gl_generator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gleam"
-version = "0.6.12"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -341,7 +341,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gleam 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gleam 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "glsl-include 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gstreamer-app 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "khronos_api"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1243,8 +1243,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gif 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4bca55ac1f213920ce3527ccd62386f1f15fa3f1714aeee1cf93f2c416903f"
-"checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
-"checksum gleam 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "f1519ca611d230e1deadbedfb79044b921ac4a961ab8823fef10e37271e2c38e"
+"checksum gl_generator 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a23d5e872a275135d66895d954269cf5e8661d234eb1c2480f4ce0d586acbd"
+"checksum gleam 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "39bb69499005e11b7b7cc0af38404a1bc0f53d954bffa8adcdb6e8d5b14f75d5"
 "checksum glib 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e8fdc159c196a5dfa53a92929ac4c10c8a6637ffb43951f3fff89c2cd2365"
 "checksum glib-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bda542f3caee39a027638e9644ff89204101ad916fd7370b585ad2c5fc97e61"
 "checksum glsl-include 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "daa2afb1631e7ab4543e0dde0e3fc68bb49c58fee89c07f30a26553b1f684ab6"
@@ -1267,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b7d43206b34b3f94ea9445174bda196e772049b9bddbc620c9d29b2d20110d"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
+"checksum khronos_api 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"

--- a/SPEC.md
+++ b/SPEC.md
@@ -37,11 +37,13 @@ A resource is a [TOML table](https://github.com/toml-lang/toml#user-content-tabl
 ### Buffer
 Configures a framebuffer object that a pass can draw to. This is the only resource type that can be referenced by the pass `buffer` configuration.
 
-- **buffer=bool**, Required, the value is ignored.
+- **buffer=list[{"u8", "f16", "f32"}]**, Required, the format of each color attachment
 - **width=u32**, Optional, defauls to the window width
 - **height=u32** , Optional, defaults to the window height
-- **attachments=u32**, Optional, defaults to 1
-- **format=string{"u8", "f16", "f32"}**: Optional, defaults to "f32"
+- **scale=f32**, Optional, scales the width and height of the buffer, defaults to 1.0
+- **components=u32**, Optional, the number of components per pixel (1=R, 2=RG, 3=RGB, 4=RGBA), defaults to 4
+- **depth=bool**, Optional, specify the depth attachment, defaults to true with U24 format
+- **depth={"u16", "u24", "u32", "f32"}**, Optional, specify the depth attachment format explicitly
 
 ### Image
 - **image=string**: Required, relative path to an image file. Supports [png, jpeg, gif, bmp, ico, tiff, webp, pnm](https://github.com/PistonDevelopers/image#21-supported-image-formats)
@@ -93,13 +95,15 @@ Each face supports the same file formats as [image](#image) input.
 
 ## Passes
 
-Passes are defined as an [array of tables](https://github.com/toml-lang/toml#array-of-tables) and are drawn in the order listed in the configuration. 
+Passes are defined as an [array of tables](https://github.com/toml-lang/toml#array-of-tables) and are drawn in the order listed in the configuration.
 
 - **buffer=string**: Optional, the buffer to draw into. If not specified, the pass draws to the default framebuffer
 - **draw={mode=string{"triangles", "points", ...}, count=u32}**: configures the draw primitive and number of vertices to draw, defaults to mode="triangles", count=1. Valid mode values: "triangles", "points", "lines", "triangle-fan", "triangle-strip", "line-strip", "line-loop"
 - **depth=string{"less",...}**: depth testing, defaults to disabled. Valid values: "never", "less", "equal", "less-equal", "greater", "not-equal", "greater-equal", "always"
+- **depth={func=string{"less",...}, write=bool}**: Specify the depth testing function and if the pass should write to the depth buffer. write defaults to true.
 - **blend={src=string{"one",..}, dest=string{"one-minus-src-alpha",..}}**: blend functions, defaults to disabled. Valid src and dest values: "zero", "one", "src-color", "one-minus-src-color", "dst-color", "one-minus-dst-color", "src-alpha", "one-minus-src-alpha", "dst-alpha", "one-minus-dst-alpha"
-- **clear=[f32;4]**: configures the clear color for the pass, defaults to [0.0, 0.0, 0.0, 1.0]
+- **clear=[f32;4]**: Optional, configures the clear color (RGBA) for the pass
+- **clear=[f32;5]**: Optional, configures the clear color (RGBA) and clear depth for the pass. The depth value is in the last component.
 
 All other key-value pairs associate a uniform sampler with a resource. grimoire uses the key name to generate uniform sampler declarations that are inserted into your code. The valid values are:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,22 +170,19 @@ pub struct PassConfig {
     pub uniform_to_channel: BTreeMap<String, ChannelConfig>,
     // render pass settings
     pub buffer: Option<String>,
-    pub clear: Option<[f32; 4]>,
+    pub clear: Option<ClearConfig>,
     pub blend: Option<BlendConfig>,
-    pub depth: Option<DepthFuncConfig>,
+    pub depth: Option<DepthTestConfig>,
     #[serde(default)]
     pub disable: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
 pub struct BufferConfig {
-    pub buffer: bool,
-    #[serde(default = "default_buffer_config_attachments")]
-    pub attachments: usize,
+    #[serde(default = "default_buffer_config_format")]
+    pub buffer: BufferFormatConfig,
     #[serde(default = "default_buffer_config_components")]
     pub components: usize,
-    #[serde(default = "default_buffer_config_format")]
-    pub format: BufferFormat,
     #[serde(default = "default_buffer_depth_config_format")]
     pub depth: BufferDepthConfig,
     pub width: Option<u32>,
@@ -193,7 +190,25 @@ pub struct BufferConfig {
     pub scale: Option<f32>,
 }
 
+impl BufferConfig {
+    pub fn attachment_count(&self) -> usize {
+        match &self.buffer {
+            BufferFormatConfig::Dumb(_) => 1,
+            BufferFormatConfig::Simple(_) => 1,
+            BufferFormatConfig::Complete(v) => v.len(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum BufferFormatConfig {
+    Dumb(bool),
+    Simple(BufferFormat),
+    Complete(Vec<BufferFormat>),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum BufferFormat {
     U8,
@@ -201,14 +216,14 @@ pub enum BufferFormat {
     F32,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
 #[serde(untagged)]
 pub enum BufferDepthConfig {
     Simple(bool),
     Complete(BufferDepthFormat),
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
 #[serde(rename_all = "lowercase")]
 pub enum BufferDepthFormat {
     U16,
@@ -223,7 +238,32 @@ pub struct DrawConfig {
     pub count: u32,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+#[serde(untagged)]
+pub enum DepthTestConfig {
+    Simple(DepthFuncConfig),
+    Complete { func: DepthFuncConfig, write: bool },
+}
+
+impl Default for DepthTestConfig {
+    fn default() -> Self {
+        DepthTestConfig::Complete {
+            func: DepthFuncConfig::Less,
+            write: true,
+        }
+    }
+}
+
+impl DepthTestConfig {
+    pub fn func(&self) -> DepthFuncConfig {
+        *(match self {
+            DepthTestConfig::Simple(func) => func,
+            DepthTestConfig::Complete { func, .. } => func,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
 pub enum DepthFuncConfig {
     #[serde(rename = "never")]
     Never,
@@ -244,12 +284,31 @@ pub enum DepthFuncConfig {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Clone)]
-pub struct BlendConfig {
+#[serde(untagged)]
+pub enum ClearDepthConfig {
+    Simple(f32),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum ClearConfig {
+    Color([f32; 4]),
+    ColorDepth([f32; 5]),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[serde(untagged)]
+pub enum BlendConfig {
+    Simple(BlendSrcDstConfig),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
+pub struct BlendSrcDstConfig {
     pub src: BlendFactorConfig,
     pub dst: BlendFactorConfig,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Clone)]
+#[derive(Debug, Deserialize, PartialEq, Clone, Copy)]
 pub enum BlendFactorConfig {
     #[serde(rename = "zero")]
     Zero,
@@ -423,18 +482,10 @@ impl EffectConfig {
                 // we simply want to check if the user set these to 0
                 let buffer_width = buffer.width.unwrap_or(1);
                 let buffer_height = buffer.height.unwrap_or(1);
-                let attachments = buffer.attachments;
                 if buffer_width == 0 || buffer_height == 0 {
                     self.ok = false;
                     error!(
                             "[TOML] Buffer \"{}\" must specify non-zero value for the width and height properties",
-                            resource_name
-                        );
-                }
-                if attachments == 0 {
-                    self.ok = false;
-                    error!(
-                            "[TOML] Buffer \"{}\" must specify non-zero value for the attachments property",
                             resource_name
                         );
                 }
@@ -469,11 +520,9 @@ impl Default for DrawConfig {
 impl Default for BufferConfig {
     fn default() -> Self {
         Self {
-            buffer: true,
-            attachments: 1,
-            components: 4,
-            format: BufferFormat::F32,
+            buffer: BufferFormatConfig::Simple(BufferFormat::F32),
             depth: BufferDepthConfig::Complete(BufferDepthFormat::U24),
+            components: 4,
             width: None,
             height: None,
             scale: Some(1.0),
@@ -526,16 +575,12 @@ const fn default_flipv() -> bool {
     true
 }
 
-const fn default_buffer_config_attachments() -> usize {
-    1
-}
-
 const fn default_buffer_config_components() -> usize {
     4
 }
 
-const fn default_buffer_config_format() -> BufferFormat {
-    BufferFormat::F32
+const fn default_buffer_config_format() -> BufferFormatConfig {
+    BufferFormatConfig::Simple(BufferFormat::F32)
 }
 
 const fn default_buffer_depth_config_format() -> BufferDepthConfig {


### PR DESCRIPTION
- Users can now specify a different format for each color attachment of a
buffer. Additionally, we simplify the buffer config schema, by
eliminating the attachment count and format keys, and roll it all into
the buffer key. This commit should be sort-of backwards compatible. Any
config that specified buffer::format will need to be updated, but that's
OK as I think we should get a parse errror/warning in those cases.
- Enable SRGB framebuffers. This was already supposed to be enabled,
but it looks like I disabled it at some point.
- Configure per-pass depth writing
- Make the depth clear value configurable
- Fix triangle strip draw count calculation
- Update the SPEC